### PR TITLE
Initial scrollview support

### DIFF
--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -27,6 +27,7 @@ type State = {
   currentStep: ?Step,
   visible: boolean,
   androidStatusBarVisible: boolean,
+  backdropColor: string,
   scrollView?: React.RefObject
 };
 
@@ -36,6 +37,7 @@ const copilot = ({
   stepNumberComponent,
   animated,
   androidStatusBarVisible,
+  backdropColor,
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -88,12 +90,12 @@ const copilot = ({
             scrollView.scrollTo({ y: yOffsett, animated: false });
           });
         }
-        
         setTimeout(() => {
           if (move) {
             this.moveToCurrentStep();
           }
-        }, this.state.scrollView ? 100 : 0);
+        }, this.state.scrollView ? 100 : 0)
+
       }
 
       setVisibility = (visible: boolean): void => new Promise((resolve) => {
@@ -158,7 +160,7 @@ const copilot = ({
           requestAnimationFrame(() => this.start(fromStep));
         } else {
           this.eventEmitter.emit('start');
-          await this.setCurrentStep(currentStep, true);
+          await this.setCurrentStep(currentStep);
           await this.moveToCurrentStep();
           await this.setVisibility(true);
           this.startTries = 0;
@@ -170,7 +172,7 @@ const copilot = ({
         this.eventEmitter.emit('stop');
       }
 
-      async  moveToCurrentStep(): void {
+      async moveToCurrentStep(): void {
         const size = await this.state.currentStep.target.measure();
 
         await this.modal.animateMove({
@@ -205,6 +207,7 @@ const copilot = ({
               overlay={overlay}
               animated={animated}
               androidStatusBarVisible={androidStatusBarVisible}
+              backdropColor={backdropColor}
               ref={(modal) => { this.modal = modal; }}
             />
           </View>

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import ReactNative from "react-native";
 import PropTypes from 'prop-types';
 
-
 import { View } from 'react-native';
 
 import mitt from 'mitt';

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -80,18 +80,20 @@ const copilot = ({
       setCurrentStep = async (step: Step, move?: boolean = true): void => {
         await this.setState({ currentStep: step });
         this.eventEmitter.emit('stepChange', step);
-        const scrollView = this.state.scrollView.current;
 
         if (this.state.scrollView) {
+          const scrollView = this.state.scrollView.current;
           const relativeSize = await this.state.currentStep.wrapper.measureLayout(ReactNative.findNodeHandle(scrollView), (x, y, w, h) => {
             const yOffsett = y > 0 ? y - (h / 2) : 0;
             scrollView.scrollTo({ y: yOffsett, animated: false });
           });
         }
-
-        if (move) {
-          this.moveToCurrentStep();
-        }
+        
+        setTimeout(() => {
+          if (move) {
+            this.moveToCurrentStep();
+          }
+        }, this.state.scrollView ? 100 : 0);
       }
 
       setVisibility = (visible: boolean): void => new Promise((resolve) => {


### PR DESCRIPTION
Added optional scrollview support. 

If a scrollview ref is provided, I set a slight timeout before measuring the next step.  There is no callback / event that I am aware of on scrollTo finish for me to call moveToCurrentStep.