### PR TITLE
Addressing issue 108 (optional wrapper style)

### DIFF
--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -36,6 +36,7 @@ const copilot = ({
   androidStatusBarVisible,
   backdropColor,
   verticalOffset = 0,
+  wrapperStyle
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -169,7 +170,7 @@ const copilot = ({
 
       render() {
         return (
-          <View style={{ flex: 1 }}>
+          <View style={wrapperStyle || { flex: 1 }}>
             <WrappedComponent
               {...this.props}
               start={this.start}


### PR DESCRIPTION
Added prop `wrapperStyle` that overrides the default wrapper style (`{flex:1}`) to give the user more control and help resolve certain display issues. Addresses https://github.com/mohebifar/react-native-copilot/issues/108