### PR TITLE
Add tooltipStyle param to customize tooltip's style

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ copilot({
 })(RootComponent)
 ```
 
+### Custom tooltip styling
+You can customize tooltip's style:
+
+```js
+const style = {
+  backgroundColor: '#9FA8DA',
+  borderRadius: 10,
+  paddingTop: 5,
+};
+
+copilot({
+  tooltipStyle: style
+})(RootComponent)
+```
+
 ### Custom step number component
 You can customize the step number by passing a component to the `copilot` HOC maker. If you are looking for an example step number component, take a look at [the default step number implementation](https://github.com/mohebifar/react-native-copilot/blob/master/src/components/StepNumber.js).
 

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -18,6 +18,7 @@ type Props = {
   easing: ?func,
   animationDuration: ?number,
   tooltipComponent: ?React$Component,
+  tooltipStyle?: Object,
   stepNumberComponent: ?React$Component,
   overlay: 'svg' | 'view',
   animated: boolean,
@@ -45,6 +46,7 @@ class CopilotModal extends Component<Props, State> {
     easing: Easing.elastic(0.7),
     animationDuration: 400,
     tooltipComponent: Tooltip,
+    tooltipStyle: {},
     stepNumberComponent: StepNumber,
     // If react-native-svg native module was avaialble, use svg as the default overlay component
     overlay: typeof NativeModules.RNSVGSvgViewManager !== 'undefined' ? 'svg' : 'view',
@@ -269,7 +271,7 @@ class CopilotModal extends Component<Props, State> {
         />
       </Animated.View>,
       <Animated.View key="arrow" style={[styles.arrow, this.state.arrow]} />,
-      <Animated.View key="tooltip" style={[styles.tooltip, this.state.tooltip]}>
+      <Animated.View key="tooltip" style={[styles.tooltip, this.props.tooltipStyle, this.state.tooltip]}>
         <TooltipComponent
           isFirstStep={this.props.isFirstStep}
           isLastStep={this.props.isLastStep}

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -31,6 +31,7 @@ type State = {
 const copilot = ({
   overlay,
   tooltipComponent,
+  tooltipStyle,
   stepNumberComponent,
   animated,
   labels,
@@ -192,6 +193,7 @@ const copilot = ({
               labels={labels}
               stepNumberComponent={stepNumberComponent}
               tooltipComponent={tooltipComponent}
+              tooltipStyle={tooltipStyle}
               overlay={overlay}
               animated={animated}
               androidStatusBarVisible={androidStatusBarVisible}


### PR DESCRIPTION
As a lib's user I want to configure my tooltip's look according to my app's design guides. 
Currently It is possible to customize only the content of the modal but it is also useful to be in control of the modal itself.
For example, to change paddings, background, border radius.