### PR TITLE
Allow to set tool tips as full width

### DIFF
--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { Animated, Easing, View, NativeModules, Modal, StatusBar, Platform } from 'react-native';
+import { Animated, Easing, View, NativeModules, Modal, StatusBar, Platform, Dimensions } from 'react-native';
 import Tooltip from './Tooltip';
 import StepNumber from './StepNumber';
 import styles, { MARGIN, ARROW_SIZE, STEP_NUMBER_DIAMETER, STEP_NUMBER_RADIUS } from './style';
@@ -26,6 +26,8 @@ type Props = {
   backdropColor: string,
   labels: Object,
   svgMaskPath?: SvgMaskPathFn,
+  fullWidthTooltips?: boolean,
+  fullWidthTooltipsHorizontalPadding?: number,
 };
 
 type State = {
@@ -38,6 +40,8 @@ type State = {
     height: number,
   },
 };
+
+const WINDOW_WIDTH: number = Dimensions.get('window').width;
 
 const noop = () => {};
 
@@ -55,6 +59,7 @@ class CopilotModal extends Component<Props, State> {
     androidStatusBarVisible: false,
     backdropColor: 'rgba(0, 0, 0, 0.4)',
     labels: {},
+    fullWidthTooltips: false,
   };
 
   state = {
@@ -154,6 +159,15 @@ class CopilotModal extends Component<Props, State> {
       tooltip.left = tooltip.left === 0 ? tooltip.left + MARGIN : tooltip.left;
       tooltip.maxWidth = layout.width - tooltip.left - MARGIN;
       arrow.left = tooltip.left + MARGIN;
+    }
+
+    if (this.props.fullWidthTooltips) {
+      const margin = this.props.fullWidthTooltipsHorizontalPadding !== undefined
+        ? this.props.fullWidthTooltipsHorizontalPadding
+        : MARGIN;
+      tooltip.maxWidth = WINDOW_WIDTH - (2 * margin);
+      tooltip.left = margin;
+      tooltip.right = margin;
     }
 
     const animate = {

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -40,6 +40,8 @@ const copilot = ({
   svgMaskPath,
   verticalOffset = 0,
   wrapperStyle,
+  fullWidthTooltips,
+  fullWidthTooltipsHorizontalPadding,
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -200,6 +202,8 @@ const copilot = ({
               backdropColor={backdropColor}
               svgMaskPath={svgMaskPath}
               ref={(modal) => { this.modal = modal; }}
+              fullWidthTooltips={fullWidthTooltips}
+              fullWidthTooltipsHorizontalPadding={fullWidthTooltipsHorizontalPadding}
             />
           </View>
         );

--- a/src/hocs/copilot.test.js
+++ b/src/hocs/copilot.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { View, Modal } from 'react-native';
+import { Dimensions, View, Modal } from 'react-native';
 import renderer from 'react-test-renderer';
 import { copilot, walkthroughable, CopilotStep } from '../index';
 import CopilotModal from '../components/CopilotModal';
@@ -164,4 +164,26 @@ it('skips a step if disabled', async () => {
   await tree.root.instance.prev();
 
   expect(textComponent.props.children).toBe('This is the description for the first step');
+});
+
+it('sets tool tips as full width', async () => {
+  const WINDOW_WIDTH = Dimensions.get('window').width;
+  const tooltipBubbleMargin = 12;
+  const TooltipComponent = () => (
+    <View />
+  );
+
+  const CopilotComponent = copilot({
+    tooltipComponent: TooltipComponent,
+    fullWidthTooltips: true,
+    fullWidthTooltipsHorizontalPadding: tooltipBubbleMargin,
+  })(SampleComponent);
+
+  const tree = renderer.create(<CopilotComponent />);
+  await tree.root.findByType(SampleComponent).props.start();
+
+  const tooltipWrapper = tree.root.findByType(TooltipComponent).parent;
+  expect(tooltipWrapper.props.style).toMatchObject({
+    maxWidth: WINDOW_WIDTH - (2 * tooltipBubbleMargin),
+  });
 });


### PR DESCRIPTION
When tool tips are pointed for an object close to the middle, the tool tip
bubble becomes very small, which makes it hard to read when there's
quite some text.

### Before 

<img alt="cramped tooltip with half of the width" width=300 src="https://user-images.githubusercontent.com/3427665/64609588-90a50100-d3cd-11e9-9a0e-97a1e4de65e6.png" />

### After

<img alt="full width tooltip with some margins" width=300 src="https://user-images.githubusercontent.com/3427665/64609181-9fd77f00-d3cc-11e9-85f5-bd0460b3940b.png" />

--- 

~~Couldn't run the tests locally, if someone can help me with this I'll gladly fix and update the tests!~~

Thank you for the very useful tool! 👏 

If this feature is something you don't wish to have it (for any reason), feel free to close 
the pull request, we needed it, so we've forked and are currently using the fork, so if
this feature ends on the tool great! If not, we'll manage it 😃