### PR TITLE
Allow to override dynamic tooltip styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,25 @@ copilot({
 })(RootComponent)
 ```
 
+
+#### Manage tooltip width
+
+Due to the dynamic way tooltip width is calculated, it is required to override both `width` and `maxWidth`, check the example bellow:
+
+```js
+const MARGIN = 8;
+const WIDTH = Dimensions.get('window').width - (2 * MARGIN);
+copilot({
+  //....
+  tooltipStyle: {
+    width: WIDTH,
+    maxWidth: WIDTH,
+    left: MARGIN,
+  },
+});
+```
+
+
 ### Custom step number component
 You can customize the step number by passing a component to the `copilot` HOC maker. If you are looking for an example step number component, take a look at [the default step number implementation](https://github.com/mohebifar/react-native-copilot/blob/master/src/components/StepNumber.js).
 

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -271,7 +271,7 @@ class CopilotModal extends Component<Props, State> {
         />
       </Animated.View>,
       <Animated.View key="arrow" style={[styles.arrow, this.state.arrow]} />,
-      <Animated.View key="tooltip" style={[styles.tooltip, this.props.tooltipStyle, this.state.tooltip]}>
+      <Animated.View key="tooltip" style={[styles.tooltip, this.state.tooltip, this.props.tooltipStyle]}>
         <TooltipComponent
           isFirstStep={this.props.isFirstStep}
           isLastStep={this.props.isLastStep}

--- a/src/hocs/copilot.test.js
+++ b/src/hocs/copilot.test.js
@@ -165,3 +165,27 @@ it('skips a step if disabled', async () => {
 
   expect(textComponent.props.children).toBe('This is the description for the first step');
 });
+
+it('allows to manage tooltip width', async () => {
+  const MyTooltipComponent = () => (
+    <View style={{ flex: 1 }} />
+  );
+  const customStyle = {
+    width: 123,
+    maxWidth: 321,
+  };
+  const CopilotComponent = copilot({
+    tooltipComponent: MyTooltipComponent,
+    tooltipStyle: customStyle,
+  })(SampleComponent);
+
+  const tree = renderer.create(<CopilotComponent />);
+  await tree.root.findByType(SampleComponent).props.start();
+
+  const tooltipWrapper = tree.root.findByType(CopilotModal)
+    .findByType(MyTooltipComponent)
+    .parent;
+
+  expect(tooltipWrapper.props.style)
+    .toMatchObject(customStyle);
+});


### PR DESCRIPTION
Improved/clear fix for https://github.com/mohebifar/react-native-copilot/pull/151

Since tooltip bubble width, heigh and position are dynamically
calculated, it doesn't allow to make it statically sized, due to this
it was not possible to change the bubble to take has much width as
possible.

This became clear when the highlighted element was in the middle of the
screen making the bubble be confined to less than half of the screen, so
with some considerable amount of text, it would look rather weird.


#### Before 

<img alt="cramped tooltip with half of the width" width=300 src="https://user-images.githubusercontent.com/3427665/64609588-90a50100-d3cd-11e9-9a0e-97a1e4de65e6.png" />

#### After

<img alt="full width tooltip with some margins" width=300 src="https://user-images.githubusercontent.com/3427665/64609181-9fd77f00-d3cc-11e9-85f5-bd0460b3940b.png" />