### PR TITLE
add support for overlay events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.*
 .DS_Store
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ copilot({
 })(RootComponent)
 ```
 
+### Tooltip arrow color
+You can customize tooltip's arrow color. Default `white`
+
+```js
+copilot({
+    borderColor: 'red'
+})(RootComponent)
+```
+
 ### Custom step number component
 You can customize the step number by passing a component to the `copilot` HOC maker. If you are looking for an example step number component, take a look at [the default step number implementation](https://github.com/mohebifar/react-native-copilot/blob/master/src/components/StepNumber.js).
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ copilot({
 })(RootComponent)
 ```
 
+### Add overlay events
+You can customize the events handled when the user clicks outside of the tooltip dialog - default `no event`.
+
+```js
+copilot({
+  overlayEvent: "next", // or "previous", "stop", "none"
+})(RootComponent)
+```
+- `next`: will go through each of the steps and finish when the end is reached
+- `previous`: will go to the previous step, if there are any previous steps
+- `stop`: will skip all the steps and end the walk-through
+- `none` or any other params: will perform no actions in case the overlay is pressed | tapped
+
 ### Custom svg mask Path 
 You can customize the mask svg path by passing a function to the `copilot` HOC maker. 
 

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -142,7 +142,7 @@ class CopilotModal extends Component<Props, State> {
       arrow.top = tooltip.top - (ARROW_SIZE * 2);
     } else {
       tooltip.bottom = layout.height - (obj.top - MARGIN);
-      arrow.borderTopColor = this.props.borderColor ||'#fff';
+      arrow.borderTopColor = this.props.borderColor || '#fff';
       arrow.bottom = tooltip.bottom - (ARROW_SIZE * 2);
     }
 

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -25,6 +25,7 @@ type Props = {
   animated: boolean,
   androidStatusBarVisible: boolean,
   backdropColor: string,
+  borderColor: string,
   labels: Object,
   svgMaskPath?: SvgMaskPathFn,
 };
@@ -137,11 +138,11 @@ class CopilotModal extends Component<Props, State> {
 
     if (verticalPosition === 'bottom') {
       tooltip.top = obj.top + obj.height + MARGIN;
-      arrow.borderBottomColor = '#fff';
+      arrow.borderBottomColor = this.props.borderColor || '#fff';
       arrow.top = tooltip.top - (ARROW_SIZE * 2);
     } else {
       tooltip.bottom = layout.height - (obj.top - MARGIN);
-      arrow.borderTopColor = '#fff';
+      arrow.borderTopColor = this.props.borderColor ||'#fff';
       arrow.bottom = tooltip.bottom - (ARROW_SIZE * 2);
     }
 

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -21,6 +21,7 @@ type Props = {
   tooltipStyle?: Object,
   stepNumberComponent: ?React$Component,
   overlay: 'svg' | 'view',
+  overlayEvent: 'next' | 'previous' | 'stop' | 'none',
   animated: boolean,
   androidStatusBarVisible: boolean,
   backdropColor: string,
@@ -233,6 +234,12 @@ class CopilotModal extends Component<Props, State> {
     /* eslint-enable */
     return (
       <MaskComponent
+        overlayEvent={this.props.overlayEvent}
+        handleNext={this.handleNext}
+        handlePrev={this.handlePrev}
+        handleStop={this.handleStop}
+        isFirstStep={this.props.isFirstStep}
+        isLastStep={this.props.isLastStep}
         animated={this.props.animated}
         layout={this.state.layout}
         style={styles.overlayContainer}

--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -5,11 +5,13 @@ import {
   Animated,
   Easing,
   Dimensions,
+  TouchableOpacity,
 } from 'react-native';
 import Svg from 'react-native-svg';
 import AnimatedSvgPath from './AnimatedPath';
 
 import type { valueXY, svgMaskPath } from '../types';
+import { getEventOnOverlay, isValidEventOnOverlay } from '../utilities';
 
 const windowDimensions = Dimensions.get('window');
 const defaultSvgPath = ({ size, position, canvasSize }): string => `M0,0H${canvasSize.x}V${canvasSize.y}H0V0ZM${position.x._value},${position.y._value}H${position.x._value + size.x._value}V${position.y._value + size.y._value}H${position.x._value}V${position.y._value}Z`;
@@ -100,8 +102,17 @@ class SvgMask extends Component<Props, State> {
   }
 
   render() {
+    // eslint-disable-next-line react/prop-types
+    const { overlayEvent } = this.props;
+    const Wrapper = isValidEventOnOverlay(overlayEvent) ? TouchableOpacity : View;
+    const eventOnOverlay = getEventOnOverlay(overlayEvent, this.props);
     return (
-      <View pointerEvents="box-none" style={this.props.style} onLayout={this.handleLayout}>
+      <Wrapper
+        onPress={() => eventOnOverlay && eventOnOverlay()}
+        pointerEvents="box-none"
+        style={this.props.style}
+        onLayout={this.handleLayout}
+      >
         {
           this.state.canvasSize
             ? (
@@ -121,7 +132,7 @@ class SvgMask extends Component<Props, State> {
             )
             : null
         }
-      </View>
+      </Wrapper>
     );
   }
 }

--- a/src/components/ViewMask.js
+++ b/src/components/ViewMask.js
@@ -1,10 +1,11 @@
 // @flow
 import React, { Component } from 'react';
 
-import { View, Animated } from 'react-native';
+import { View, Animated, TouchableOpacity } from 'react-native';
 import styles from './style';
 
 import type { valueXY } from '../types';
+import { getEventOnOverlay, isValidEventOnOverlay } from '../utilities';
 
 type Props = {
   size: valueXY,
@@ -28,8 +29,14 @@ type State = {
 
 class ViewMask extends Component<Props, State> {
   state = {
-    size: new Animated.ValueXY({ x: 0, y: 0 }),
-    position: new Animated.ValueXY({ x: 0, y: 0 }),
+    size: new Animated.ValueXY({
+      x: 0,
+      y: 0,
+    }),
+    position: new Animated.ValueXY({
+      x: 0,
+      y: 0,
+    }),
   };
 
   componentWillReceiveProps(nextProps) {
@@ -51,13 +58,14 @@ class ViewMask extends Component<Props, State> {
           duration: this.props.animationDuration,
           easing: this.props.easing,
         }),
-      ]).start();
+      ])
+        .start();
     } else {
       this.state.size.setValue(size);
       this.state.position.setValue(position);
       this.setState({ animated: this.props.animated });
     }
-  }
+  };
 
   render() {
     const { size, position } = this.state;
@@ -73,8 +81,13 @@ class ViewMask extends Component<Props, State> {
       width, Animated.multiply(-1, rightOverlayLeft),
     );
 
+    // eslint-disable-next-line react/prop-types
+    const { overlayEvent } = this.props;
+    const Wrapper = isValidEventOnOverlay(overlayEvent) ? TouchableOpacity : View;
+    const eventOnOverlay = getEventOnOverlay(overlayEvent, this.props);
+
     return (
-      <View style={this.props.style}>
+      <Wrapper style={this.props.style} onPress={() => eventOnOverlay && eventOnOverlay()}>
         <Animated.View
           style={[
             styles.overlayRectangle,
@@ -113,7 +126,7 @@ class ViewMask extends Component<Props, State> {
             },
           ]}
         />
-      </View>
+      </Wrapper>
     );
   }
 }

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -38,6 +38,7 @@ const copilot = ({
   labels,
   androidStatusBarVisible,
   backdropColor,
+  borderColor,
   svgMaskPath,
   verticalOffset = 0,
   wrapperStyle,
@@ -200,6 +201,7 @@ const copilot = ({
               animated={animated}
               androidStatusBarVisible={androidStatusBarVisible}
               backdropColor={backdropColor}
+              borderColor={borderColor}
               svgMaskPath={svgMaskPath}
               ref={(modal) => { this.modal = modal; }}
             />

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -30,6 +30,7 @@ type State = {
 
 const copilot = ({
   overlay,
+  overlayEvent,
   tooltipComponent,
   tooltipStyle,
   stepNumberComponent,
@@ -195,6 +196,7 @@ const copilot = ({
               tooltipComponent={tooltipComponent}
               tooltipStyle={tooltipStyle}
               overlay={overlay}
+              overlayEvent={overlayEvent}
               animated={animated}
               androidStatusBarVisible={androidStatusBarVisible}
               backdropColor={backdropColor}

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -23,3 +23,21 @@ export const getNextStep = (steps: Array<Step>, step: ?Step): number => Object
   .values(steps)
   .filter(_step => _step.order > step.order)
   .reduce((a, b) => (!a || a.order > b.order ? b : a), null) || step;
+
+export const isValidEventOnOverlay = (eventOnOverlay: string) => (eventOnOverlay === 'next' || eventOnOverlay === 'previous' || eventOnOverlay === 'stop');
+
+export const getEventOnOverlay = (eventOnOverlay: string, props: Object) => {
+  const {
+    handleNext, handlePrev, handleStop, isFirstStep, isLastStep,
+  } = props;
+  switch (eventOnOverlay) {
+    case 'next':
+      return isLastStep ? handleStop : handleNext;
+    case 'previous':
+      return isFirstStep ? null : handlePrev;
+    case 'stop':
+      return handleStop;
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
- Added support for handling events when the user presses outside of the tooltip dialog.

supported events `next`, `previous`, `stop`

To get this version use:

```
    "react-native-copilot": "git+https://github.com/valdio/react-native-copilot.git",
```