### PR TITLE
Add verticalOffset function support #106

### DIFF
--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -180,7 +180,7 @@ const copilot = ({
 
       async moveToCurrentStep(): void {
         const size = await this.state.currentStep.target.measure();
-
+		    if (typeof verticalOffset === "function") verticalOffset = await verticalOffset();
         await this.modal.animateMove({
           width: size.width + OFFSET_WIDTH,
           height: size.height + OFFSET_WIDTH,


### PR DESCRIPTION
Specifically in react native navigation, the vertical offset is wrong on android (#106). This commit allows passing in an async function that can be executed at runtime to decide vertical offset based on the specific devices statusbar and topbar height (in react native navigations case, using await Navigation.constants() )