### PR TITLE
Pass useNativeDriver: false to all Animated.timing calls.

### DIFF
--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -170,6 +170,7 @@ class CopilotModal extends Component<Props, State> {
             toValue: animate[key],
             duration: this.props.animationDuration,
             easing: this.props.easing,
+            useNativeDriver: false,
           })))
         .start();
     } else {

--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -78,11 +78,13 @@ class SvgMask extends Component<Props, State> {
           toValue: size,
           duration: this.props.animationDuration,
           easing: this.props.easing,
+          useNativeDriver: false,
         }),
         Animated.timing(this.state.position, {
           toValue: position,
           duration: this.props.animationDuration,
           easing: this.props.easing,
+          useNativeDriver: false,
         }),
       ]).start();
     } else {

--- a/src/components/ViewMask.js
+++ b/src/components/ViewMask.js
@@ -46,11 +46,13 @@ class ViewMask extends Component<Props, State> {
           toValue: size,
           duration: this.props.animationDuration,
           easing: this.props.easing,
+          useNativeDriver: false,
         }),
         Animated.timing(this.state.position, {
           toValue: position,
           duration: this.props.animationDuration,
           easing: this.props.easing,
+          useNativeDriver: false,
         }),
       ]).start();
     } else {


### PR DESCRIPTION
Resolves #178. The only change is adding the line ```useNativeDriver: false``` to four `Animated.timing` calls--one in CopilotModal.js, two in SvgMask.js, and two in ViewMask.js. I think that ideally, we would set `useNativeDriver` to `true`, but that currently causes errors. For now, this PR fixes the warnings that result from `useNativeDriver` not being set.

`useNativeDriver` is now required as of react-native v0.62.0. (See https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#deprecated). This is why warnings are being generated.

Cheers,
-Cooper


