### PR TITLE
Added an 'arrowColor' prop to change the arrow color in the tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ copilot({
 });
 ```
 
+### Custom tooltip arrow color
+
+You can customize the tooltip's arrow color:
+
+```js
+copilot({
+  arrowColor: '#FF00FF'
+})(RootComponent);
+```
 
 ### Custom step number component
 

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -27,6 +27,7 @@ type Props = {
   labels: Object,
   svgMaskPath?: SvgMaskPathFn,
   stopOnOutsideClick?: boolean,
+  arrowColor?: string,
 };
 
 type State = {
@@ -57,6 +58,7 @@ class CopilotModal extends Component<Props, State> {
     backdropColor: 'rgba(0, 0, 0, 0.4)',
     labels: {},
     stopOnOutsideClick: false,
+    arrowColor: '#fff',
   };
 
   state = {
@@ -138,11 +140,11 @@ class CopilotModal extends Component<Props, State> {
 
     if (verticalPosition === 'bottom') {
       tooltip.top = obj.top + obj.height + MARGIN;
-      arrow.borderBottomColor = '#fff';
+      arrow.borderBottomColor = this.props.arrowColor;
       arrow.top = tooltip.top - (ARROW_SIZE * 2);
     } else {
       tooltip.bottom = layout.height - (obj.top - MARGIN);
-      arrow.borderTopColor = '#fff';
+      arrow.borderTopColor = this.props.arrowColor;
       arrow.bottom = tooltip.bottom - (ARROW_SIZE * 2);
     }
 

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -43,6 +43,7 @@ const copilot = ({
   svgMaskPath,
   verticalOffset = 0,
   wrapperStyle,
+  arrowColor,
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -218,6 +219,7 @@ const copilot = ({
               backdropColor={backdropColor}
               svgMaskPath={svgMaskPath}
               stopOnOutsideClick={stopOnOutsideClick}
+              arrowColor={arrowColor}
               ref={(modal) => { this.modal = modal; }}
             />
           </View>


### PR DESCRIPTION
Created an `arrowColor` property to allow people to change the arrow color if desired
Addresses parts of:
[#91 Change Arrow Color and backdrop color](https://github.com/mohebifar/react-native-copilot/issues/91)
[#120 How to change styles for "tooltip white background color" and "arrow" ?](https://github.com/mohebifar/react-native-copilot/issues/120)
[#129 BackgroundColor of tooltip donst work](https://github.com/mohebifar/react-native-copilot/issues/129)
