### PR TITLE
Make Tooltip position-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ const TooltipComponent = ({
   handlePrev,
   handleStop,
   currentStep,
+  horizontalPosition,
+  verticalPosition,
 }) => (
   // ...
 );

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -39,6 +39,8 @@ type State = {
     width: number,
     height: number,
   },
+  tooltipHorizontalPosition: 'left' | 'right',
+  tooltipVerticalPosition: 'top' | 'bottom',
 };
 
 const noop = () => {};
@@ -70,6 +72,8 @@ class CopilotModal extends Component<Props, State> {
     },
     animated: false,
     containerVisible: false,
+    tooltipVerticalPosition: 'top',
+    tooltipHorizontalPosition: 'left',
   };
 
   componentDidUpdate(prevProps: Props) {
@@ -194,6 +198,8 @@ class CopilotModal extends Component<Props, State> {
         x: Math.floor(Math.max(obj.left, 0)),
         y: Math.floor(Math.max(obj.top, 0)),
       },
+      tooltipHorizontalPosition: horizontalPosition,
+      tooltipVerticalPosition: verticalPosition,
     });
   }
 
@@ -293,6 +299,8 @@ class CopilotModal extends Component<Props, State> {
           handlePrev={this.handlePrev}
           handleStop={this.handleStop}
           labels={this.props.labels}
+          horizontalPosition={this.state.tooltipHorizontalPosition}
+          verticalPosition={this.state.tooltipVerticalPosition}
         />
       </Animated.View>,
     ];

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -16,6 +16,8 @@ type Props = {
   handleStop: func,
   currentStep: Step,
   labels: Object,
+  horizontalPosition: 'left' | 'right',
+  verticalPosition: 'top' | 'bottom',
 };
 
 const Tooltip = ({


### PR DESCRIPTION
Add the `horizontalPosition` and `verticalPosition` props to the Tooltip component, so that custom Tooltip components can use that information for things like rendering custom arrows.

(In my particular case, we wanted to render white text directly over the mask, and render a white SVG arrow that points in the correct direction for the highlighted element.)

Part of a series of PRs for more flexible styling:
* https://github.com/mohebifar/react-native-copilot/pull/238