### PR TITLE
Add prop to specify back button behavior

### DIFF
--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -41,8 +41,6 @@ type State = {
   },
 };
 
-const noop = () => {};
-
 class CopilotModal extends Component<Props, State> {
   static defaultProps = {
     easing: Easing.elastic(0.7),
@@ -54,6 +52,7 @@ class CopilotModal extends Component<Props, State> {
     overlay: typeof NativeModules.RNSVGSvgViewManager !== 'undefined' ? 'svg' : 'view',
     // If animated was not specified, rely on the default overlay type
     animated: typeof NativeModules.RNSVGSvgViewManager !== 'undefined',
+    onBackButton: 'noop',
     androidStatusBarVisible: false,
     backdropColor: 'rgba(0, 0, 0, 0.4)',
     labels: {},
@@ -236,6 +235,15 @@ class CopilotModal extends Component<Props, State> {
     }
   };
 
+  handleBackButton = () => {
+    if (this.props.onBackButton === 'stop') {
+      this.handleStop();
+    } else if (this.props.onBackButton === 'prev') {
+      this.handlePrev();
+    }
+    // if not otherwise specified, do nothing
+  }
+
   renderMask() {
     /* eslint-disable global-require */
     const MaskComponent = this.props.overlay === 'svg'
@@ -306,7 +314,7 @@ class CopilotModal extends Component<Props, State> {
       <Modal
         animationType="none"
         visible={containerVisible}
-        onRequestClose={noop}
+        onRequestClose={this.handleBackButton}
         transparent
         supportedOrientations={['portrait', 'landscape']}
       >

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,7 @@ declare module 'react-native-copilot' {
     overlay?: OverlayType; // The overlay in react-native copilot is the component that draws the dark transparent over the root component.
     tooltipComponent?: any; // You can customize the tooltip by passing a component here
     stepNumberComponent?: any; // You can customize the step number by passing a component here
+    onBackButton: 'noop' | 'prev' | 'stop'; // specifies what to do when the back button is pressed, either no-op, move to previous step, or stop
     androidStatusBarVisible?: boolean; // Whether the Android status bar should be visible
     backdropColor?: string; // You can customize the mask color - default is rgba(0, 0, 0, 0.4)
     verticalOffset?: number; // In order to adjust vertical position


### PR DESCRIPTION
Adds a prop that allows configuration of back button behavior. By default, it's still a no-op, but also allows either navigation to the previous step, or stopping the walkthrough all together.

This was especially helpful in my case, because the tutorial as designed did not use buttons (clicking the mask or the tooltip would advance the tutorial), so it's helpful for the back button to still behave as the user expects.

Part of a series of PRs for more flexible styling:
* https://github.com/mohebifar/react-native-copilot/pull/238
* https://github.com/mohebifar/react-native-copilot/pull/239