### PR TITLE
Customizable arrow size

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ copilot({
 })(RootComponent);
 ```
 
+### Custom tooltip arrow size
+
+You can customize the tooltip's arrow size:
+
+```js
+copilot({
+  arrowSize: 9
+})(RootComponent);
+```
+
 ### Custom step number component
 
 You can customize the step number by passing a component to the `copilot` HOC maker. If you are looking for an example step number component, take a look at [the default step number implementation](https://github.com/mohebifar/react-native-copilot/blob/master/src/components/StepNumber.js).

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Animated, Easing, View, NativeModules, Modal, StatusBar, Platform } from 'react-native';
 import Tooltip from './Tooltip';
 import StepNumber from './StepNumber';
-import styles, { MARGIN, ARROW_SIZE, STEP_NUMBER_DIAMETER, STEP_NUMBER_RADIUS } from './style';
+import styles, { MARGIN, STEP_NUMBER_DIAMETER, STEP_NUMBER_RADIUS } from './style';
 import type { SvgMaskPathFn } from '../types';
 
 type Props = {
@@ -28,6 +28,7 @@ type Props = {
   svgMaskPath?: SvgMaskPathFn,
   stopOnOutsideClick?: boolean,
   arrowColor?: string,
+  arrowSize?: string,
 };
 
 type State = {
@@ -59,6 +60,7 @@ class CopilotModal extends Component<Props, State> {
     labels: {},
     stopOnOutsideClick: false,
     arrowColor: '#fff',
+    arrowSize: 6,
   };
 
   state = {
@@ -136,16 +138,18 @@ class CopilotModal extends Component<Props, State> {
     const horizontalPosition = relativeToLeft > relativeToRight ? 'left' : 'right';
 
     const tooltip = {};
-    const arrow = {};
+    const arrow = {
+      borderWidth: this.props.arrowSize,
+    };
 
     if (verticalPosition === 'bottom') {
       tooltip.top = obj.top + obj.height + MARGIN;
       arrow.borderBottomColor = this.props.arrowColor;
-      arrow.top = tooltip.top - (ARROW_SIZE * 2);
+      arrow.top = tooltip.top - (this.props.arrowSize * 2);
     } else {
       tooltip.bottom = layout.height - (obj.top - MARGIN);
       arrow.borderTopColor = this.props.arrowColor;
-      arrow.bottom = tooltip.bottom - (ARROW_SIZE * 2);
+      arrow.bottom = tooltip.bottom - (this.arrowSize * 2);
     }
 
     if (horizontalPosition === 'left') {

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -6,7 +6,6 @@ export const STEP_NUMBER_DIAMETER: number = STEP_NUMBER_RADIUS * 2;
 export const ZINDEX: number = 100;
 export const MARGIN: number = 13;
 export const OFFSET_WIDTH: number = 4;
-export const ARROW_SIZE: number = 6;
 
 export default StyleSheet.create({
   container: {
@@ -20,7 +19,6 @@ export default StyleSheet.create({
   arrow: {
     position: 'absolute',
     borderColor: 'transparent',
-    borderWidth: ARROW_SIZE,
   },
   tooltip: {
     position: 'absolute',

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -44,6 +44,7 @@ const copilot = ({
   verticalOffset = 0,
   wrapperStyle,
   arrowColor,
+  arrowSize,
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -220,6 +221,7 @@ const copilot = ({
               svgMaskPath={svgMaskPath}
               stopOnOutsideClick={stopOnOutsideClick}
               arrowColor={arrowColor}
+              arrowSize={arrowSize}
               ref={(modal) => { this.modal = modal; }}
             />
           </View>


### PR DESCRIPTION
Adds the ability to customize the arrow size, similar to what we have for the arrowColor.

The const `ARROW_SIZE` was removed and the default style for arrow does not include borderWith anymore. It was moved as the default value for the new property property `arrowSize` of CopilotModal that is used in place of the old const.

The borderWith is now in `state.arrow` and not in `styles.arrow`, but as they are merged in [this code](https://github.com/mohebifar/react-native-copilot/blob/master/src/components/CopilotModal.js#L286) it produces the same results.

Instructions was also added to the README:

### Custom tooltip arrow size

You can customize the tooltip's arrow size:

```js
copilot({
  arrowSize: 9
})(RootComponent);
```