### PR TITLE
Expose more APIs

### DIFF
--- a/.changeset/calm-phones-carry.md
+++ b/.changeset/calm-phones-carry.md
@@ -1,0 +1,8 @@
+---
+"react-native-copilot": minor
+---
+
+Expose more functions through the public API
+
+Expose `stop`, `goToNext`, `goToNth`, and `goToPrev` through the `useCopilot` hook
+Export `DefaultUI` from the module's entry to access the default Tooltip and StepNumber components

--- a/example/package.json
+++ b/example/package.json
@@ -13,9 +13,10 @@
     "expo-build-properties": "~0.5.1",
     "expo-dev-client": "~2.1.5",
     "expo-status-bar": "~1.4.4",
+    "expo-updates": "~0.16.3",
     "react": "18.2.0",
     "react-native": "0.71.3",
-    "react-native-copilot": "^3.0.0",
+    "react-native-copilot": "latest",
     "react-native-svg": "13.4.0"
   },
   "devDependencies": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3634,6 +3634,11 @@ expo-dev-menu@2.1.4:
     expo-dev-menu-interface "1.1.1"
     semver "^7.3.5"
 
+expo-eas-client@~0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/expo-eas-client/-/expo-eas-client-0.5.1.tgz#3ef80dbbde13abe35be4e2a2e29b73d2f7fdf27a"
+  integrity sha512-i3L/iwhI6cFhSUpVsCxSU5qehNznL/rQFYoof6qUIh3CMyijCuTEwjEhwbw2a5W6obPBzQUXbomMSFDO6D5/0Q==
+
 expo-file-system@~15.2.0, expo-file-system@~15.2.2:
   version "15.2.2"
   resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-15.2.2.tgz#a1ddf8aabf794f93888a146c4f5187e2004683a3"
@@ -3689,10 +3694,32 @@ expo-status-bar@~1.4.4:
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.4.4.tgz#6874ccfda5a270d66f123a9f220735a76692d114"
   integrity sha512-5DV0hIEWgatSC3UgQuAZBoQeaS9CqeWRZ3vzBR9R/+IUD87Adbi4FGhU10nymRqFXOizGsureButGZIXPs7zEA==
 
+expo-structured-headers@~3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/expo-structured-headers/-/expo-structured-headers-3.1.1.tgz#198d44260f4b128d41313ef78df02fa6e20c5054"
+  integrity sha512-oV6yNGsJxQt7S9HYZTr+4L0I/yRwOF38USJ81I1KiN3GQI4C2z7P5OosyREA2VL9O+kUZVCCpNYsBLSa3/5bAQ==
+
 expo-updates-interface@~0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/expo-updates-interface/-/expo-updates-interface-0.9.1.tgz#e81308d551ed5a4c35c8770ac61434f6ca749610"
   integrity sha512-wk88LLhseQ7LJvxdN7BTKiryyqALxnrvr+lyHK3/prg76Yy0EGi2Q/oE/rtFyyZ1JmQDRbO/5pdX0EE6QqVQXQ==
+
+expo-updates@~0.16.3:
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.16.3.tgz#190f5896f98db2e130b608d61c8359ee4b2c2125"
+  integrity sha512-uFr2Fvq7IbKwz9xEqWE9GNEs0sBAd6uiUI9McTCKw4BzKhjylRbPAN3zewc7MGLOvhTwBASva79VLQVgzdoBRw==
+  dependencies:
+    "@expo/code-signing-certificates" "0.0.5"
+    "@expo/config" "~8.0.0"
+    "@expo/config-plugins" "~6.0.0"
+    "@expo/metro-config" "~0.7.0"
+    arg "4.1.0"
+    expo-eas-client "~0.5.0"
+    expo-manifests "~0.5.0"
+    expo-structured-headers "~3.1.0"
+    expo-updates-interface "~0.9.0"
+    fbemitter "^3.0.0"
+    resolve-from "^5.0.0"
 
 expo@~48.0.6:
   version "48.0.7"
@@ -6535,10 +6562,10 @@ react-native-codegen@^0.71.5:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
-react-native-copilot@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-copilot/-/react-native-copilot-3.0.0.tgz#bf7d06dd2f883a76f88c637c4410c6d2502132cd"
-  integrity sha512-0rWurZp1lydH3MqyZHWEJMGZzS1mNtoORmAbEC84JvQOFGcfvVUNW/cDr1J6M51hmmOZZ70a3DQBtTZHmn66DQ==
+react-native-copilot@latest:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-copilot/-/react-native-copilot-3.0.1.tgz#3da03e238f1b174386f7ffdaa5dc0dfaf4018f0a"
+  integrity sha512-Y3VHZxJqKsZsQxNEaiJPLLcnFZmfIRkpk56v5n0eHWYv+OfF/kz1eeZhfYV5es+BiHwjvfG1zJjLHaepKbQsKQ==
   dependencies:
     "@changesets/changelog-github" "^0.4.8"
     "@changesets/cli" "^2.26.0"

--- a/src/contexts/CopilotProvider.tsx
+++ b/src/contexts/CopilotProvider.tsx
@@ -33,6 +33,7 @@ interface CopilotContextType {
     fromStep?: string,
     suppliedScrollView?: ScrollView | null
   ) => Promise<void>;
+  stop: () => Promise<void>;
   visible: boolean;
   copilotEvents: Emitter<Events>;
 }
@@ -169,10 +170,10 @@ export const CopilotProvider = ({
     ]
   );
 
-  const stop = async () => {
+  const stop = useCallback(async () => {
     await setVisibility(false);
     copilotEvents.emit("stop");
-  };
+  }, [copilotEvents, setVisibility]);
 
   const value = useMemo(
     () => ({
@@ -180,10 +181,19 @@ export const CopilotProvider = ({
       unregisterStep,
       getCurrentStep,
       start,
+      stop,
       visible,
       copilotEvents,
     }),
-    [registerStep, unregisterStep, getCurrentStep, start, visible, copilotEvents]
+    [
+      registerStep,
+      unregisterStep,
+      getCurrentStep,
+      start,
+      stop,
+      visible,
+      copilotEvents,
+    ]
   );
 
   return (

--- a/src/contexts/CopilotProvider.tsx
+++ b/src/contexts/CopilotProvider.tsx
@@ -34,6 +34,9 @@ interface CopilotContextType {
     suppliedScrollView?: ScrollView | null
   ) => Promise<void>;
   stop: () => Promise<void>;
+  goToNext: () => Promise<void>;
+  goToNth: (n: number) => Promise<void>;
+  goToPrev: () => Promise<void>;
   visible: boolean;
   copilotEvents: Emitter<Events>;
 }
@@ -72,18 +75,6 @@ export const CopilotProvider = ({
     unregisterStep,
     getCurrentStep,
   } = useStepsMap();
-
-  const next = async () => {
-    await setCurrentStep(getNextStep());
-  };
-
-  const nth = async (n: number) => {
-    await setCurrentStep(getNthStep(n));
-  };
-
-  const prev = async () => {
-    await setCurrentStep(getPrevStep());
-  };
 
   const moveModalToStep = useCallback(
     async (step: Step) => {
@@ -175,6 +166,21 @@ export const CopilotProvider = ({
     copilotEvents.emit("stop");
   }, [copilotEvents, setVisibility]);
 
+  const next = useCallback(async () => {
+    await setCurrentStep(getNextStep());
+  }, [getNextStep, setCurrentStep]);
+
+  const nth = useCallback(
+    async (n: number) => {
+      await setCurrentStep(getNthStep(n));
+    },
+    [getNthStep, setCurrentStep]
+  );
+
+  const prev = useCallback(async () => {
+    await setCurrentStep(getPrevStep());
+  }, [getPrevStep, setCurrentStep]);
+
   const value = useMemo(
     () => ({
       registerStep,
@@ -184,6 +190,9 @@ export const CopilotProvider = ({
       stop,
       visible,
       copilotEvents,
+      goToNext: next,
+      goToNth: nth,
+      goToPrev: prev,
     }),
     [
       registerStep,
@@ -193,6 +202,9 @@ export const CopilotProvider = ({
       stop,
       visible,
       copilotEvents,
+      next,
+      nth,
+      prev,
     ]
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { StepNumber } from "./components/default-ui/StepNumber";
+import { Tooltip } from "./components/default-ui/Tooltip";
 export { walkthroughable } from "./hocs/walkthroughable";
 export { CopilotStep } from "./components/CopilotStep";
 export { CopilotProvider, useCopilot } from "./contexts/CopilotProvider";
@@ -6,3 +8,8 @@ export type {
   StepNumberProps,
   TooltipProps,
 } from "./types";
+
+export const DefaultUI = {
+  StepNumber,
+  Tooltip,
+};


### PR DESCRIPTION
Expose more functions through the public API

Expose `stop`, `goToNext`, `goToNth`, and `goToPrev` through the `useCopilot` hook
Export `DefaultUI` from the module's entry to access the default Tooltip and StepNumber components
