### PR TITLE
V3.2

### DIFF
--- a/.changeset/blue-paws-refuse.md
+++ b/.changeset/blue-paws-refuse.md
@@ -1,0 +1,7 @@
+---
+"react-native-copilot": minor
+---
+
+Remove Tooltip and StepNumber passed props in favor of useCopilot context
+Un-register the step after name change and re-register with the new name
+Add tests for CopilotStep

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "tsup",
     "dev": "NODE_ENV=development yarn build --watch",
     "lint": "eslint src/",
-    "test": "jest src/",
+    "test": "jest",
     "changeset": "changeset",
     "release": "changeset publish"
   },
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/mohebifar/react-native-copilot#readme",
   "devDependencies": {
+    "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react-native": "^12.0.0",
     "@tsconfig/react-native": "^2.0.3",
     "@types/jest": "^29.5.0",

--- a/src/components/CopilotModal.tsx
+++ b/src/components/CopilotModal.tsx
@@ -18,28 +18,19 @@ import {
   type LayoutRectangle,
   type ViewStyle,
 } from "react-native";
-import type { CopilotOptions, Step } from "../types";
+import { useCopilot } from "../contexts/CopilotProvider";
+import type { CopilotOptions } from "../types";
 import { StepNumber } from "./default-ui/StepNumber";
 import { Tooltip } from "./default-ui/Tooltip";
 import {
-  styles,
   ARROW_SIZE,
   MARGIN,
   STEP_NUMBER_DIAMETER,
   STEP_NUMBER_RADIUS,
+  styles,
 } from "./style";
 
-type Props = CopilotOptions & {
-  prev: () => Promise<void>;
-  next: () => Promise<void>;
-  stop: () => Promise<void>;
-  nth: (stepNumber: number) => Promise<void>;
-  currentStepNumber?: number;
-  currentStep?: Step;
-  visible: boolean;
-  isFirstStep: boolean;
-  isLastStep: boolean;
-};
+type Props = CopilotOptions;
 
 const noop = () => {};
 
@@ -57,15 +48,6 @@ export interface CopilotModalHandle {
 export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
   function CopilotModal(
     {
-      stop,
-      prev,
-      next,
-      nth,
-      currentStepNumber,
-      currentStep,
-      visible,
-      isFirstStep,
-      isLastStep,
       easing = Easing.elastic(0.7),
       animationDuration = 400,
       tooltipComponent: TooltipComponent = Tooltip,
@@ -89,6 +71,7 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
     },
     ref
   ) {
+    const { stop, currentStep, visible } = useCopilot();
     const [tooltipStyles, setTooltipStyles] = useState({});
     const [arrowStyles, setArrowStyles] = useState({});
     const [animatedValues] = useState({
@@ -262,18 +245,6 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
       setLayout(undefined);
     };
 
-    const handleNext = () => {
-      void next();
-    };
-
-    const handleNth = (index: number) => {
-      void nth(index);
-    };
-
-    const handlePrev = () => {
-      void prev();
-    };
-
     const handleStop = () => {
       reset();
       void stop();
@@ -365,12 +336,7 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
               },
             ]}
           >
-            <StepNumberComponent
-              isFirstStep={isFirstStep}
-              isLastStep={isLastStep}
-              currentStep={currentStep}
-              currentStepNumber={currentStepNumber ?? 0}
-            />
+            <StepNumberComponent />
           </Animated.View>
 
           <Animated.View key="arrow" style={[styles.arrow, arrowStyles]} />
@@ -378,16 +344,7 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
             key="tooltip"
             style={[styles.tooltip, tooltipStyles, tooltipStyle]}
           >
-            <TooltipComponent
-              isFirstStep={isFirstStep}
-              isLastStep={isLastStep}
-              currentStep={currentStep}
-              handleNext={handleNext}
-              handleNth={handleNth}
-              handlePrev={handlePrev}
-              handleStop={handleStop}
-              labels={labels}
-            />
+            <TooltipComponent labels={labels} />
           </Animated.View>
         </>
       );

--- a/src/components/CopilotStep.tsx
+++ b/src/components/CopilotStep.tsx
@@ -51,6 +51,9 @@ export const CopilotStep = ({
 
   useEffect(() => {
     if (active) {
+      if (registeredName.current && registeredName.current !== name) {
+        unregisterStep(registeredName.current);
+      }
       registerStep({
         name,
         text,

--- a/src/components/default-ui/StepNumber.tsx
+++ b/src/components/default-ui/StepNumber.tsx
@@ -1,11 +1,15 @@
-import React from "react";
-import { View, Text } from "react-native";
-import { type StepNumberProps } from "../../types";
+import React, { type FunctionComponent } from "react";
+import { Text, View } from "react-native";
+import { useCopilot } from "../../contexts/CopilotProvider";
 
 import { styles } from "../style";
 
-export const StepNumber = ({ currentStepNumber }: StepNumberProps) => (
-  <View style={styles.stepNumber}>
-    <Text style={[styles.stepNumberText]}>{currentStepNumber}</Text>
-  </View>
-);
+export const StepNumber: FunctionComponent<unknown> = () => {
+  const { currentStepNumber } = useCopilot();
+
+  return (
+    <View style={styles.stepNumber}>
+      <Text style={styles.stepNumberText}>{currentStepNumber}</Text>
+    </View>
+  );
+};

--- a/src/components/default-ui/Tooltip.tsx
+++ b/src/components/default-ui/Tooltip.tsx
@@ -6,42 +6,51 @@ import { Button } from "./Button";
 import { styles } from "../style";
 
 import type { TooltipProps } from "../../types";
+import { useCopilot } from "../../contexts/CopilotProvider";
 
-export const Tooltip = ({
-  isFirstStep,
-  isLastStep,
-  handleNext,
-  handlePrev,
-  handleStop,
-  currentStep,
-  labels,
-}: TooltipProps) => (
-  <View>
-    <View style={styles.tooltipContainer}>
-      <Text testID="stepDescription" style={styles.tooltipText}>
-        {currentStep.text}
-      </Text>
+export const Tooltip = ({ labels }: TooltipProps) => {
+  const { goToNext, goToPrev, stop, currentStep, isFirstStep, isLastStep } =
+    useCopilot();
+
+  const handleStop = () => {
+    void stop();
+  };
+  const handleNext = () => {
+    void goToNext();
+  };
+
+  const handlePrev = () => {
+    void goToPrev();
+  };
+
+  return (
+    <View>
+      <View style={styles.tooltipContainer}>
+        <Text testID="stepDescription" style={styles.tooltipText}>
+          {currentStep?.text}
+        </Text>
+      </View>
+      <View style={[styles.bottomBar]}>
+        {!isLastStep ? (
+          <TouchableOpacity onPress={handleStop}>
+            <Button>{labels.skip}</Button>
+          </TouchableOpacity>
+        ) : null}
+        {!isFirstStep ? (
+          <TouchableOpacity onPress={handlePrev}>
+            <Button>{labels.previous}</Button>
+          </TouchableOpacity>
+        ) : null}
+        {!isLastStep ? (
+          <TouchableOpacity onPress={handleNext}>
+            <Button>{labels.next}</Button>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity onPress={handleStop}>
+            <Button>{labels.finish}</Button>
+          </TouchableOpacity>
+        )}
+      </View>
     </View>
-    <View style={[styles.bottomBar]}>
-      {!isLastStep ? (
-        <TouchableOpacity onPress={handleStop}>
-          <Button>{labels.skip}</Button>
-        </TouchableOpacity>
-      ) : null}
-      {!isFirstStep ? (
-        <TouchableOpacity onPress={handlePrev}>
-          <Button>{labels.previous}</Button>
-        </TouchableOpacity>
-      ) : null}
-      {!isLastStep ? (
-        <TouchableOpacity onPress={handleNext}>
-          <Button>{labels.next}</Button>
-        </TouchableOpacity>
-      ) : (
-        <TouchableOpacity onPress={handleStop}>
-          <Button>{labels.finish}</Button>
-        </TouchableOpacity>
-      )}
-    </View>
-  </View>
-);
+  );
+};

--- a/src/components/tests/CopilotStep.test.tsx
+++ b/src/components/tests/CopilotStep.test.tsx
@@ -1,0 +1,197 @@
+import "@testing-library/jest-native/extend-expect";
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+import {
+  CopilotProvider,
+  type useCopilot,
+} from "../../contexts/CopilotProvider";
+import { CopilotStep } from "../CopilotStep";
+
+jest.mock("../../contexts/CopilotProvider", () => ({
+  ...jest.requireActual("../../contexts/CopilotProvider"),
+  useCopilot: jest
+    .fn()
+    .mockImplementation(
+      () => jest.requireActual("../../contexts/CopilotProvider").useCopilot
+    ),
+}));
+
+const actualUseCopilot = jest.requireActual("../../contexts/CopilotProvider")
+  .useCopilot as typeof useCopilot;
+
+const mockUseCopilot = jest.requireMock("../../contexts/CopilotProvider")
+  .useCopilot as jest.Mock<ReturnType<typeof useCopilot>>;
+
+describe("CopilotStep", () => {
+  beforeEach(() => {
+    mockUseCopilot.mockClear().mockImplementation(actualUseCopilot);
+  });
+
+  test("passes the copilot prop to the child component", async () => {
+    const WrappedComponent = () => null;
+
+    render(
+      <CopilotProvider>
+        <CopilotStep name="Test" order={0} text="Hello">
+          <WrappedComponent />
+        </CopilotStep>
+      </CopilotProvider>
+    );
+    const wrappedComponentElement = screen.UNSAFE_getByType(WrappedComponent);
+
+    expect(wrappedComponentElement.props).toMatchObject({
+      copilot: {
+        onLayout: expect.any(Function),
+        ref: expect.any(Object),
+      },
+    });
+  });
+
+  test("registers the step", async () => {
+    const WrappedComponent = () => null;
+    const registerStepSpy = jest.fn();
+
+    mockUseCopilot.mockReturnValue({
+      registerStep: registerStepSpy,
+      unregisterStep: jest.fn(),
+      stop: jest.fn(),
+    } as any);
+
+    render(
+      <CopilotProvider>
+        <>
+          <CopilotStep name="Step 1" order={0} text="Hello! This is step 1!">
+            <WrappedComponent />
+          </CopilotStep>
+          <CopilotStep name="Step 2" order={1} text="And this is step 2">
+            <WrappedComponent />
+          </CopilotStep>
+        </>
+      </CopilotProvider>
+    );
+
+    expect(registerStepSpy).toHaveBeenCalledWith({
+      measure: expect.any(Function),
+      name: "Step 1",
+      text: "Hello! This is step 1!",
+      order: 0,
+      visible: expect.any(Boolean),
+      wrapperRef: expect.any(Object),
+    });
+
+    expect(registerStepSpy).toHaveBeenCalledWith({
+      measure: expect.any(Function),
+      name: "Step 2",
+      text: "And this is step 2",
+      order: 1,
+      visible: expect.any(Boolean),
+      wrapperRef: expect.any(Object),
+    });
+  });
+
+  test("re-registers the step after text update", async () => {
+    const WrappedComponent = () => null;
+    const registerStepSpy = jest.fn();
+
+    mockUseCopilot.mockReturnValue({
+      registerStep: registerStepSpy,
+      unregisterStep: jest.fn(),
+      stop: jest.fn(),
+    } as any);
+
+    render(
+      <CopilotProvider>
+        <CopilotStep name="Step 1" order={0} text="Hello! This is step 1!">
+          <WrappedComponent />
+        </CopilotStep>
+      </CopilotProvider>
+    );
+
+    screen.rerender(
+      <CopilotProvider>
+        <CopilotStep
+          name="Step 1"
+          order={0}
+          text="Hello! This is the same step with updated text!"
+        >
+          <WrappedComponent />
+        </CopilotStep>
+      </CopilotProvider>
+    );
+
+    expect(registerStepSpy).toHaveBeenCalledWith({
+      measure: expect.any(Function),
+      name: "Step 1",
+      text: "Hello! This is the same step with updated text!",
+      order: 0,
+      visible: expect.any(Boolean),
+      wrapperRef: expect.any(Object),
+    });
+  });
+
+  test("unregisters the step after unmount", async () => {
+    const WrappedComponent = () => null;
+    const registerStepSpy = jest.fn();
+    const unregisterStepSpy = jest.fn();
+
+    mockUseCopilot.mockReturnValue({
+      registerStep: registerStepSpy,
+      unregisterStep: unregisterStepSpy,
+      stop: jest.fn(),
+    } as any);
+
+    render(
+      <CopilotProvider>
+        <CopilotStep name="Step 1" order={0} text="Hello! This is step 1!">
+          <WrappedComponent />
+        </CopilotStep>
+      </CopilotProvider>
+    );
+
+    // Remove the step from the tree
+    screen.rerender(<CopilotProvider />);
+
+    expect(unregisterStepSpy).toHaveBeenCalledWith("Step 1");
+  });
+
+  test("unregisters the step after name change and re-registers with the new name", async () => {
+    const WrappedComponent = () => null;
+    const registerStepSpy = jest.fn();
+    const unregisterStepSpy = jest.fn();
+
+    mockUseCopilot.mockReturnValue({
+      registerStep: registerStepSpy,
+      unregisterStep: unregisterStepSpy,
+      stop: jest.fn(),
+    } as any);
+
+    const stepText = "Hello! This is step 1!";
+
+    render(
+      <CopilotProvider>
+        <CopilotStep name="Step 1" order={0} text={stepText}>
+          <WrappedComponent />
+        </CopilotStep>
+      </CopilotProvider>
+    );
+
+    screen.rerender(
+      <CopilotProvider>
+        <CopilotStep name="Step 1 Updated Name" order={0} text={stepText}>
+          <WrappedComponent />
+        </CopilotStep>
+      </CopilotProvider>
+    );
+
+    expect(unregisterStepSpy).toHaveBeenCalledWith("Step 1");
+
+    expect(registerStepSpy).toHaveBeenCalledWith({
+      measure: expect.any(Function),
+      name: "Step 1 Updated Name",
+      text: stepText,
+      order: 0,
+      visible: expect.any(Boolean),
+      wrapperRef: expect.any(Object),
+    });
+  });
+});

--- a/src/contexts/CopilotProvider.tsx
+++ b/src/contexts/CopilotProvider.tsx
@@ -28,7 +28,7 @@ type Events = {
 interface CopilotContextType {
   registerStep: (step: Step) => void;
   unregisterStep: (stepName: string) => void;
-  getCurrentStep: () => Step | undefined;
+  currentStep: Step | undefined;
   start: (
     fromStep?: string,
     suppliedScrollView?: ScrollView | null
@@ -39,6 +39,9 @@ interface CopilotContextType {
   goToPrev: () => Promise<void>;
   visible: boolean;
   copilotEvents: Emitter<Events>;
+  isFirstStep: boolean;
+  isLastStep: boolean;
+  currentStepNumber: number;
 }
 
 /*
@@ -62,7 +65,8 @@ export const CopilotProvider = ({
   const [scrollView, setScrollView] = useState<ScrollView | null>(null);
 
   const {
-    getStepNumber,
+    currentStep,
+    currentStepNumber,
     getFirstStep,
     getPrevStep,
     getNextStep,
@@ -73,7 +77,6 @@ export const CopilotProvider = ({
     steps,
     registerStep,
     unregisterStep,
-    getCurrentStep,
   } = useStepsMap();
 
   const moveModalToStep = useCallback(
@@ -185,7 +188,7 @@ export const CopilotProvider = ({
     () => ({
       registerStep,
       unregisterStep,
-      getCurrentStep,
+      currentStep,
       start,
       stop,
       visible,
@@ -193,11 +196,14 @@ export const CopilotProvider = ({
       goToNext: next,
       goToNth: nth,
       goToPrev: prev,
+      isFirstStep,
+      isLastStep,
+      currentStepNumber,
     }),
     [
       registerStep,
       unregisterStep,
-      getCurrentStep,
+      currentStep,
       start,
       stop,
       visible,
@@ -205,6 +211,9 @@ export const CopilotProvider = ({
       next,
       nth,
       prev,
+      isFirstStep,
+      isLastStep,
+      currentStepNumber,
     ]
   );
 
@@ -212,15 +221,6 @@ export const CopilotProvider = ({
     <CopilotContext.Provider value={value}>
       <>
         <CopilotModal
-          prev={prev}
-          next={next}
-          stop={stop}
-          nth={nth}
-          currentStepNumber={getStepNumber()}
-          currentStep={getCurrentStep()}
-          visible={visible}
-          isFirstStep={isFirstStep}
-          isLastStep={isLastStep}
           ref={modal}
           {...rest}
         />

--- a/src/hocs/tests/walkthroughable.test.tsx
+++ b/src/hocs/tests/walkthroughable.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, Text, ScrollView, TextInput } from "react-native";
 import renderer from "react-test-renderer";
-import { walkthroughable } from "./walkthroughable";
+import { walkthroughable } from "../walkthroughable";
 
 const WalkthroughableView = walkthroughable(View);
 const WalkthroughableText = walkthroughable(Text);

--- a/src/hooks/useStepsMap.ts
+++ b/src/hooks/useStepsMap.ts
@@ -36,7 +36,7 @@ export const useStepsMap = () => {
     [steps]
   );
 
-  const getStepIndex = useCallback(
+  const stepIndex = useCallback(
     (step = currentStep) =>
       step
         ? orderedSteps.findIndex(
@@ -46,9 +46,9 @@ export const useStepsMap = () => {
     [currentStep, orderedSteps]
   );
 
-  const getStepNumber = useCallback(
-    (step = currentStep) => getStepIndex(step) + 1,
-    [currentStep, getStepIndex]
+  const currentStepNumber = useMemo(
+    (step = currentStep) => stepIndex(step) + 1,
+    [currentStep, stepIndex]
   );
 
   const getFirstStep = useCallback(() => orderedSteps[0], [orderedSteps]);
@@ -59,13 +59,13 @@ export const useStepsMap = () => {
   );
 
   const getPrevStep = useCallback(
-    (step = currentStep) => step && orderedSteps[getStepIndex(step) - 1],
-    [currentStep, getStepIndex, orderedSteps]
+    (step = currentStep) => step && orderedSteps[stepIndex(step) - 1],
+    [currentStep, stepIndex, orderedSteps]
   );
 
   const getNextStep = useCallback(
-    (step = currentStep) => step && orderedSteps[getStepIndex(step) + 1],
-    [currentStep, getStepIndex, orderedSteps]
+    (step = currentStep) => step && orderedSteps[stepIndex(step) + 1],
+    [currentStep, stepIndex, orderedSteps]
   );
 
   const getNthStep = useCallback(
@@ -91,10 +91,8 @@ export const useStepsMap = () => {
     dispatch({ type: "unregister", stepName });
   }, []);
 
-  const getCurrentStep = useCallback(() => currentStep, [currentStep]);
-
   return {
-    getStepNumber,
+    currentStepNumber,
     getFirstStep,
     getLastStep,
     getPrevStep,
@@ -102,7 +100,7 @@ export const useStepsMap = () => {
     getNthStep,
     isFirstStep,
     isLastStep,
-    getCurrentStep,
+    currentStep,
     setCurrentStepState,
     steps,
     registerStep,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,7 @@ import { Tooltip } from "./components/default-ui/Tooltip";
 export { walkthroughable } from "./hocs/walkthroughable";
 export { CopilotStep } from "./components/CopilotStep";
 export { CopilotProvider, useCopilot } from "./contexts/CopilotProvider";
-export type {
-  CopilotOptions as CopilotProps,
-  StepNumberProps,
-  TooltipProps,
-} from "./types";
+export type { CopilotOptions as CopilotProps, TooltipProps } from "./types";
 
 export const DefaultUI = {
   StepNumber,

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,21 +42,7 @@ export type Labels = Partial<
   Record<"skip" | "previous" | "next" | "finish", string>
 >;
 
-export interface StepNumberProps {
-  currentStepNumber: number;
-  isFirstStep: boolean;
-  isLastStep: boolean;
-  currentStep: Step;
-}
-
 export interface TooltipProps {
-  isFirstStep: boolean;
-  isLastStep: boolean;
-  handleNext: () => void;
-  handleNth: (n: number) => void;
-  handlePrev: () => void;
-  handleStop: () => void;
-  currentStep: Step;
   labels: Labels;
 }
 
@@ -81,9 +67,9 @@ export interface CopilotOptions {
   easing?: ((value: number) => number) | undefined;
   overlay?: "svg" | "view";
   animationDuration?: number;
-  tooltipComponent?: React.ComponentType<any>;
+  tooltipComponent?: React.ComponentType<TooltipProps>;
   tooltipStyle?: ViewStyle;
-  stepNumberComponent?: React.ComponentType<any>;
+  stepNumberComponent?: React.ComponentType<any >;
   animated?: boolean;
   labels?: Labels;
   androidStatusBarVisible?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1696,6 +1696,17 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
+"@testing-library/jest-native@^5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-5.4.2.tgz#6b0c987cc57f8d900763e763025d00d26ccbc85f"
+  integrity sha512-Vo/CE1uvCVH1H8YPoOEXLXVsm+BjzSQTq35+wkri1fr0O5D+A2WZ+m3ni5g6f1OCzNKNGIAHmisBEWkDs1P1mw==
+  dependencies:
+    chalk "^4.1.2"
+    jest-diff "^29.0.1"
+    jest-matcher-utils "^29.0.1"
+    pretty-format "^29.0.3"
+    redent "^3.0.0"
+
 "@testing-library/react-native@^12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-12.0.0.tgz#6604b9daa9a32b1a4287c3b501658768adaf11c3"
@@ -4670,7 +4681,7 @@ jest-config@^29.5.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^29.5.0:
+jest-diff@^29.0.1, jest-diff@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.5.0.tgz#e0d83a58eb5451dcc1fa61b1c3ee4e8f5a290d63"
   integrity sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==
@@ -4747,7 +4758,7 @@ jest-leak-detector@^29.5.0:
     jest-get-type "^29.4.3"
     pretty-format "^29.5.0"
 
-jest-matcher-utils@^29.5.0:
+jest-matcher-utils@^29.0.1, jest-matcher-utils@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz#d957af7f8c0692c5453666705621ad4abc2c59c5"
   integrity sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==
@@ -6327,7 +6338,7 @@ pretty-format@^26.5.2, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^29.0.0, pretty-format@^29.5.0:
+pretty-format@^29.0.0, pretty-format@^29.0.3, pretty-format@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.5.0.tgz#283134e74f70e2e3e7229336de0e4fce94ccde5a"
   integrity sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==


### PR DESCRIPTION
Remove Tooltip and StepNumber passed props in favor of useCopilot context
Un-register the step after name change and re-register with the new name
Add tests for CopilotStep