### PR TITLE
fix(android): fix malformed field crash, add more config

### DIFF
--- a/src/components/CopilotModal.tsx
+++ b/src/components/CopilotModal.tsx
@@ -68,6 +68,8 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
       svgMaskPath,
       stopOnOutsideClick = false,
       arrowColor = "#fff",
+      arrowSize = ARROW_SIZE,
+      margin = MARGIN
     },
     ref
   ) {
@@ -154,13 +156,13 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
         const arrow: ViewStyle = {};
 
         if (verticalPosition === "bottom") {
-          tooltip.top = rect.y + rect.height + MARGIN;
+          tooltip.top = rect.y + rect.height + margin;
           arrow.borderBottomColor = arrowColor;
-          arrow.top = tooltip.top - ARROW_SIZE * 2;
+          arrow.top = tooltip.top - arrowSize * 2;
         } else {
-          tooltip.bottom = newMeasuredLayout.height - (rect.y - MARGIN);
+          tooltip.bottom = newMeasuredLayout.height - (rect.y - margin);
           arrow.borderTopColor = arrowColor;
-          arrow.bottom = tooltip.bottom - ARROW_SIZE * 2;
+          arrow.bottom = tooltip.bottom - arrowSize * 2;
         }
 
         if (horizontalPosition === "left") {
@@ -169,16 +171,20 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
             0
           );
           tooltip.right =
-            tooltip.right === 0 ? tooltip.right + MARGIN : tooltip.right;
-          tooltip.maxWidth = newMeasuredLayout.width - tooltip.right - MARGIN;
-          arrow.right = tooltip.right + MARGIN;
+            tooltip.right === 0 ? tooltip.right + margin : tooltip.right;
+          tooltip.maxWidth = newMeasuredLayout.width - tooltip.right - margin;
+          arrow.right = tooltip.right + margin;
         } else {
           tooltip.left = Math.max(rect.x, 0);
           tooltip.left =
-            tooltip.left === 0 ? tooltip.left + MARGIN : tooltip.left;
-          tooltip.maxWidth = newMeasuredLayout.width - tooltip.left - MARGIN;
-          arrow.left = tooltip.left + MARGIN;
+            tooltip.left === 0 ? tooltip.left + margin : tooltip.left;
+          tooltip.maxWidth = newMeasuredLayout.width - tooltip.left - margin;
+          arrow.left = tooltip.left + margin;
         }
+
+        sanitize(arrow)
+        sanitize(tooltip)
+        sanitize(rect)
 
         const animate = [
           ["top", rect.y],
@@ -219,6 +225,8 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
         arrowColor,
         easing,
         isAnimated,
+        arrowSize,
+        margin,
       ]
     );
 
@@ -303,6 +311,8 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
 
       const position = maskRect;
 
+      if (backdropColor === 'transparent') return null
+
       return (
         <MaskComponent
           animated={animated}
@@ -339,7 +349,9 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
             <StepNumberComponent />
           </Animated.View>
 
-          <Animated.View key="arrow" style={[styles.arrow, arrowStyles]} />
+          {!!arrowSize && (
+            <Animated.View key="arrow" style={[styles.arrow, arrowStyles]} />
+          )}
           <Animated.View
             key="tooltip"
             style={[styles.tooltip, tooltipStyles, tooltipStyle]}
@@ -351,3 +363,25 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
     }
   }
 );
+
+const floorify = (obj: Record<string, any>) => {
+  Object.keys(obj).forEach((key) => {
+    if (typeof obj[key] === "number") {
+      obj[key] = Math.floor(obj[key]);
+    }
+  });
+};
+
+const removeNan = (obj: Record<string, any>) => {
+  Object.keys(obj).forEach((key) => {
+    if (typeof obj[key] === "number" && isNaN(obj[key])) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete obj[key];
+    }
+  });
+};
+
+const sanitize = (obj: Record<any, any>) => {
+  floorify(obj);
+  removeNan(obj);
+}

--- a/src/components/CopilotModal.tsx
+++ b/src/components/CopilotModal.tsx
@@ -311,8 +311,6 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
 
       const position = maskRect;
 
-      if (backdropColor === 'transparent') return null
-
       return (
         <MaskComponent
           animated={animated}

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,8 @@ export interface CopilotOptions {
   svgMaskPath?: SvgMaskPathFunction;
   verticalOffset?: number;
   arrowColor?: string;
+  arrowSize?: number
+  margin?: number
   stopOnOutsideClick?: boolean;
   backdropColor?: string;
 }


### PR DESCRIPTION
Added a few optimizations and configuration options:

- Set arrow size (or 0 to hide it)
- Set margin size
- floored/removed NaN properties from layouts (was causing android crashes due to malformed field sizes on Pixel 5a)